### PR TITLE
Include doc and tests in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,7 @@ include HISTORY.txt
 include LICENSE.txt
 include README.txt
 include version.txt
+graft doc
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
We at Gentoo rely on PyPI tarballs whenever possible to build doc and run tests; this project doesn't include them any more (1.2.4 had tests). Could you please include doc and re-add tests for future releases?