### PR TITLE
Add check name to check constructor

### DIFF
--- a/nagiosplugin/check.py
+++ b/nagiosplugin/check.py
@@ -27,19 +27,24 @@ _log = logging.getLogger(__name__)
 
 class Check(object):
 
-    def __init__(self, *objects):
+    def __init__(self, *objects, **kwargs):
         """Creates and configures a check.
 
         Specialized *objects* representing resources, contexts,
         summary, or results are passed to the the :meth:`add` method.
         Alternatively, objects can be added later manually.
+        If no *name* is given, the output prefix is set to the first
+        resource's name. If *name* is None, so prefix is set at all.
         """
         self.resources = []
         self.contexts = Contexts()
         self.summary = Summary()
         self.results = Results()
         self.perfdata = []
-        self.name = ''
+        if 'name' in kwargs and kwargs['name'] != '':
+            self.name = kwargs['name']
+        else:
+            self.name = ''
         self.add(*objects)
 
     def add(self, *objects):
@@ -54,7 +59,9 @@ class Check(object):
         for obj in objects:
             if isinstance(obj, Resource):
                 self.resources.append(obj)
-                if self.name == '':
+                if self.name is None:
+                    self.name = ''
+                elif self.name == '':
                     self.name = self.resources[0].name
             elif isinstance(obj, Context):
                 self.contexts.add(obj)

--- a/nagiosplugin/output.py
+++ b/nagiosplugin/output.py
@@ -39,7 +39,7 @@ class Output(object):
         summary_str = check.summary_str.strip()
         return self._screen_chars('{0}{1}{2}'.format(
             name_prefix, str(check.state).upper(),
-            ' - ' + summary_str if summary_str else ''), 'status line')
+            ' - ' + summary_str if summary_str else ''), 'status line').strip()
 
     def format_perfdata(self, check, linebreak=None):
         if not check.perfdata:


### PR DESCRIPTION
This allows to explicitly set the output prefix/check name at creation time or to clear it with name=None.
Omitting the name results in the default behaviour (output prefix = 1st resource name)