### PR TITLE
setup.cfg: get rid of UserWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [upload_docs]
-upload-dir = doc/_build/html
+upload_dir = doc/_build/html


### PR DESCRIPTION
Before that change, we would see:
> UserWarning: Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead