### PR TITLE
Harden GitHub security and add CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+What does this change do, and why?
+
+## Related issue
+
+Fixes #... / Relates to #... / None
+
+## Testing
+
+What did you test locally? Include relevant platforms or Python versions.
+
+## Compatibility and security
+
+Does this change alter public behavior, handle untrusted input, introduce a
+breaking change, or have other security implications?
+
+## Checklist
+
+- [ ] I have read and followed the [contribution guide](https://github.com/mpounsett/nagiosplugin/blob/main/HACKING.txt)
+- [ ] Tests were added or updated where appropriate
+- [ ] Documentation and history were updated where appropriate
+- [ ] The PR title clearly describes the change

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    target-branch: main
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:00"
+      timezone: America/Toronto
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:00"
+      timezone: America/Toronto
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/security/bandit-baseline.json
+++ b/.github/security/bandit-baseline.json
@@ -1,0 +1,26 @@
+{
+  "results": [
+    {
+      "code": "57     if original_function is not None:\n58         assert callable(original_function), (\n59             'Function {!r} not callable. Forgot to add \"verbose=\" keyword?'.\n60             format(original_function))\n61         return _decorate(original_function)\n",
+      "col_offset": 8,
+      "end_col_offset": 38,
+      "filename": "nagiosplugin/runtime.py",
+      "issue_confidence": "HIGH",
+      "issue_cwe": {
+        "id": 703,
+        "link": "https://cwe.mitre.org/data/definitions/703.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "line_number": 58,
+      "line_range": [
+        58,
+        59,
+        60
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b101_assert_used.html",
+      "test_id": "B101",
+      "test_name": "assert_used"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,141 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --editable . --group lint
+      - name: Run tests
+        run: python -m pytest tests
+
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --editable . --group docs
+      - name: Build documentation
+        run: make docs
+
+  quality:
+    name: Ruff critical checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Install Ruff
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff
+      - name: Reject critical Python errors
+        run: >-
+          ruff check
+          --isolated
+          --select E9,F63,F7,F82
+          nagiosplugin tests
+
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Install security tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --editable . --group lint bandit pip-audit
+      - name: Reject new Bandit findings
+        run: >-
+          bandit
+          --configfile bandit.toml
+          --recursive nagiosplugin
+          --baseline .github/security/bandit-baseline.json
+      - name: Audit Python dependencies
+        run: pip-audit --skip-editable
+
+  required:
+    name: Required
+    if: ${{ always() }}
+    needs:
+      - tests
+      - documentation
+      - quality
+      - security
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify required jobs
+        env:
+          DOCUMENTATION_RESULT: ${{ needs.documentation.result }}
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+        run: |
+          if [[ "$TESTS_RESULT" != "success" ||
+                "$DOCUMENTATION_RESULT" != "success" ||
+                "$QUALITY_RESULT" != "success" ||
+                "$SECURITY_RESULT" != "success" ]]; then
+            echo "One or more required CI jobs did not succeed."
+            exit 1
+          fi

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -4,41 +4,48 @@ Contributing to Nagiosplugin
 Getting the source
 ------------------
 
-The source can be obtained via git from
-https://github.com/mpounsett/nagiosplugin.git::
+Create a fork of https://github.com/mpounsett/nagiosplugin on GitHub, then clone
+your fork and add the main repository as the ``upstream`` remote::
 
-   git clone https://github.com/mpounsett/nagiosplugin.git
+   git clone https://github.com/YOUR-USERNAME/nagiosplugin.git
+   cd nagiosplugin
+   git remote add upstream https://github.com/mpounsett/nagiosplugin.git
 
-This package supports installation in a virtualenv::
+This package supports installation in a virtual environment::
 
-   python3 -m venv .
-   pip install -e .
+   python3 -m venv .venv
+   . .venv/bin/activate
+   python -m pip install -e . --group dev
 
 
 Making Changes
 --------------
 
-This project uses the `Git-flow workflow`_, approximately as laid out by
-Vincent Driessen in 2010.  New development should be done in feature branches,
-which are branched off of the `develop` branch.  PRs should be sent to
-`upstream:develop`.
-
-.. _Git-flow workflow: https://nvie.com/posts/a-successful-git-branching-model/
+The ``main`` branch is the only long-lived branch. New development should be
+done in short-lived branches created from an up-to-date ``main`` branch. Pull
+requests should target ``upstream:main``.
 
 Consider whether your change updates or fixes any existing issues.  Include
 the appropriate "fixes" or "updates" entry in your PR description so that the
 issue is updated.   If your change does not reference an existing issue,
 consider creating an issue to link it to.
 
-Branches should be prefixed `feat/*` or `fix/*` depending on whether it is a
-new feature or a bug fix, followd by the relevant issue number, followed by a
-few keywords to describe the change. (e.g. `feat/001-add-widget-support`).
-Maintainers may create housekeeping branches prefixed by `chore/`.
+Branches should be prefixed ``feat/`` or ``fix/`` depending on whether the
+change is a new feature or a bug fix, followed by the relevant issue number and
+a few words describing the change (for example,
+``feat/001-add-widget-support``). Maintainers may create housekeeping branches
+prefixed by ``chore/``.
 
-Run the full set of tests using `tox` before sending a PR.  Your change should
-trigger no **new** errors or warnings.  Note that, at present, much of the old
-codebase gets warnings related to the `pylint` and `pydocstyle` tests.  Your
-changes must not introduce any **new** warnings from these tests.
+Push the branch to your fork and open a pull request against the main
+repository's ``main`` branch. GitHub Actions will run the supported Python test
+matrix and other required checks. A maintainer will review external
+contributions before merging them.
+
+Run the relevant tests locally before sending a PR. GitHub Actions runs the full
+supported Python matrix. Your change should trigger no **new** errors or
+warnings. Note that, at present, much of the old codebase gets warnings related
+to the ``pylint`` and ``pydocstyle`` tests. Your changes must not introduce any
+**new** warnings from these tests.
 
 If your change is a new feature, or otherwise alters the behaviour of
 `nagiosplugin`, update the relevant section of the documentation and include
@@ -55,8 +62,8 @@ this is by installing and using `pyenv`_.
 .. _pyenv: https://github.com/pyenv/pyenv
 
 Once you have `pyenv` set up, make sure you have each of the supported
-versions of python specified by the `envlist` in `tox.ini`.  This will likely
-look something like::
+versions of Python specified by the ``envlist`` in ``pyproject.toml``. This
+will likely look something like::
 
    pyenv install 3.13.14
    pyenv install 3.12.13
@@ -75,11 +82,22 @@ After doing so, run the unit tests::
 
 To limit tests to a particular python environment::
 
-   tox -e py37
+   tox -e py313
 
 Run only linting tests::
 
    tox -e ruff
+
+Run the security checks::
+
+   tox -e bandit,pip-audit
+
+Continuous integration compares Bandit results with the reviewed baseline in
+``.github/security/bandit-baseline.json``. Existing baseline findings are
+reported without blocking unrelated work, while new findings fail the required
+security check. Do not update the baseline without reviewing the finding and
+recording why it cannot be fixed immediately. ``pip-audit`` currently has no
+baseline findings, so any detected vulnerable dependency fails its check.
 
 **nagiosplugin** also includes support for test coverage reports. Coverage
 reports are updated automatically by `tox`. Open `htmlcov/index.html` to see
@@ -131,9 +149,10 @@ Begin by making sure you have the build prerequisites installed::
 
    pip install -e --group build
 
-Create a release branch from `develop`::
+Create a release branch from ``main``::
 
-   git checkout develop
+   git checkout main
+   git pull --ff-only
    git checkout -b release/0.1.2
 
 Check that all tests pass.  Apply hotfixes as necessary to pass all tests
@@ -169,34 +188,30 @@ Do a test upload with TestPyPi::
 Check on https://test.pypi.org/nagiosplugin that the package metadata looks
 correct.  If everything is fine, proceed with the next steps.
 
-Commit the updated history and version files, making sure both of the file
-changes are in the same commit.  For a new version `0.1.2`::
+Commit the updated history and version files, making sure both files are in the
+same commit. For a new version ``0.1.2``::
 
    git stage HISTORY.txt nagiosplugin/version.py
    git commit -m "Preparing release 0.1.2"
 
-Merge the release into the `main` branch and tag the release::
+Push the release branch and open a pull request against ``main``. After all
+required checks pass, merge the pull request, update your local ``main`` branch,
+and tag the merge result::
 
+   git push -u origin release/0.1.2
    git checkout main
-   git merge release/0.1.2
+   git pull --ff-only
    git tag 0.1.2
-   git push
-   git push --tags
+   git push origin 0.1.2
 
 Build the final **nagiosplugin** distribution for PyPi, and upload it::
 
    python -m build
    twine upload dist/*
 
-Merge the release back into `develop` and then delete the release branch::
-
-   git checkout develop
-   git merge release/0.1.2
-   git push
-   git branch -d release/0.1.2
-
-Go to https://readthedocs.io/ and ensure the new stable and dev releases are
-available.
+Go to https://readthedocs.io/ and ensure the new stable release and the latest
+documentation from ``main`` are available. The release branch will be deleted
+automatically after its pull request is merged.
 
 
 .. vim: set ft=rst sw=3 sts=3 et:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are made for the latest released version of `nagiosplugin`.
+Users should upgrade to the newest release before reporting a problem that may
+already have been fixed.
+
+## Reporting a vulnerability
+
+Please do not report suspected vulnerabilities in a public issue or discussion.
+Instead, use [GitHub private vulnerability reporting][report] to send a private
+report to the maintainer.
+
+Include enough information to reproduce and assess the problem, where possible:
+
+- the affected version and environment;
+- a description of the impact;
+- reproduction steps or a minimal proof of concept; and
+- any suggested mitigation or fix.
+
+You will receive an acknowledgement after the report has been reviewed. The
+maintainer will coordinate disclosure and credit with the reporter as the issue
+is investigated and fixed.
+
+[report]: https://github.com/mpounsett/nagiosplugin/security/advisories/new


### PR DESCRIPTION
## Summary

- add required Python, documentation, critical Ruff, Bandit, and pip-audit CI
- baseline the existing Bandit B101 finding so only new findings fail
- add a security policy, private reporting guidance, PR template, and Dependabot version updates
- update contribution and release documentation for the main-only workflow

This PR is the transition point before fast-forwarding `main` to `develop` and making `main` the default branch.

## Testing

- Python 3.13: 140 passed, 1 skipped
- Bandit baseline: no new findings
- pip-audit: no known vulnerabilities
- Ruff critical checks: passed
- Sphinx HTML documentation: built successfully
- workflow and Dependabot YAML: parsed successfully

## Compatibility and security

This does not change the package runtime behavior. GitHub-hosted workflows use a read-only token, immutable action SHAs, no secrets, and no contributor-controlled privileged workflow.

## Checklist

- [x] I have read and followed the [contribution guide](https://github.com/mpounsett/nagiosplugin/blob/main/HACKING.txt)
- [x] Tests were added or updated where appropriate
- [x] Documentation and history were updated where appropriate
- [x] The PR title clearly describes the change
