### PR TITLE
Add PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --group build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check --strict dist/*
+
+      - name: Store distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish distribution
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nagiosplugin
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        with:
+          attestations: true

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -147,7 +147,8 @@ below examples.
 
 Begin by making sure you have the build prerequisites installed::
 
-   pip install -e --group build
+   python -m pip install --upgrade pip
+   python -m pip install --group build
 
 Create a release branch from ``main``::
 
@@ -170,7 +171,7 @@ which you can edit down to just a list of relevant changes::
 
    git log --reverse --no-merges 0.1.1... > new-changes.txt
 
-Do a test build of the distribution for the PyPi test site::
+Do a test build of the distribution for the PyPI test site::
 
    python -m build
 
@@ -179,9 +180,9 @@ the expected files.
 
 Test your package prior to uploading::
 
-   twine check dist/dist/nagiosplugin-0.1.2.tar.gz
+   twine check --strict dist/*
 
-Do a test upload with TestPyPi::
+Do a test upload with TestPyPI::
 
    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
@@ -204,10 +205,20 @@ and tag the merge result::
    git tag 0.1.2
    git push origin 0.1.2
 
-Build the final **nagiosplugin** distribution for PyPi, and upload it::
+Create a GitHub release using the existing tag. Add suitable release notes and
+publish the release. Publishing the GitHub release starts the trusted-publishing
+workflow::
 
-   python -m build
-   twine upload dist/*
+   gh release create 0.1.2 --verify-tag --generate-notes
+
+Approve the ``pypi`` environment deployment when prompted. GitHub Actions will
+build and check both distributions in a job without publishing credentials,
+then use a short-lived PyPI credential to upload them from the isolated publish
+job. The workflow also produces PyPI publish attestations. No long-lived PyPI
+token is stored in GitHub.
+
+Verify that the workflow completed successfully and that the new release is
+visible at https://pypi.org/project/nagiosplugin/.
 
 Go to https://readthedocs.io/ and ensure the new stable release and the latest
 documentation from ``main`` are available. The release branch will be deleted


### PR DESCRIPTION
## Summary

Add a dedicated, least-privilege GitHub Actions workflow for publishing releases to PyPI with OIDC trusted publishing and attestations. Update HACKING.txt so publishing a GitHub Release replaces the local production twine upload.

## Testing

- Parsed the workflow YAML
- Built the wheel and sdist from a clean main-based worktree
- Passed `twine check --strict` for both distributions

## Compatibility and security

The build and publish jobs are separated. Only the two-step publish job receives `id-token: write`; all third-party actions are pinned to immutable commits. The publisher is scoped to the `pypi` environment.

## Checklist

- [x] I have read HACKING.txt
- [x] I tested the relevant changes
- [x] I updated contributor or release documentation where needed