### PR TITLE
Use lockfile-only Dependabot updates for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   - package-ecosystem: uv
     directory: /
     target-branch: main
+    # Preserve Python-version-specific development-tool resolutions in uv.lock.
+    versioning-strategy: lockfile-only
     schedule:
       interval: monthly
       day: monday


### PR DESCRIPTION
## Summary

Configure Dependabot's uv updater to modify `uv.lock` without rewriting the
development dependency requirements in `pyproject.toml`.

The default strategy attempted to pin every tool to its newest release. That
made the update unsatisfiable across the project's supported Python range—for
example, pytest 9 requires Python 3.10 while nagiosplugin still supports Python
3.9. The existing lockfile correctly resolves compatible versions for each
Python version, which `lockfile-only` preserves.

This does not change the separate GitHub Actions updater.

## Related issue

Relates to failed Dependabot update #1470503404.

## Testing

- parsed `.github/dependabot.yml` with Ruby's YAML parser
- ran `git diff --check`
- confirmed `lockfile-only` is supported for the uv ecosystem in GitHub's
  Dependabot configuration reference

## Compatibility and security

Runtime dependencies and package behavior are unchanged. Dependabot will
continue updating resolved development-tool versions where the project's
declared Python compatibility permits them.

## Checklist

- [x] I have read and followed the [contribution guide](https://github.com/mpounsett/nagiosplugin/blob/main/HACKING.txt)
- [x] Tests were added or updated where appropriate
- [x] Documentation and history were updated where appropriate
- [x] The PR title clearly describes the change
