### PR TITLE
fix typo in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -29,4 +29,4 @@ python:
     - method: uv
       command: sync
       groups:
-        - doc
+        - docs


### PR DESCRIPTION
## Summary

Fix `doc` vs `docs` dependency group name in `.readthedocs.yaml`.

